### PR TITLE
Dirty exception hook

### DIFF
--- a/src/dumpulator/dumpulator.py
+++ b/src/dumpulator/dumpulator.py
@@ -3,7 +3,7 @@ import struct
 import sys
 import traceback
 from enum import IntEnum
-from typing import List, Union, NamedTuple
+from typing import List, Union, NamedTuple, Callable
 import inspect
 from collections import OrderedDict
 
@@ -17,6 +17,7 @@ from .native import *
 from .details import *
 from .memory import *
 from .modules import *
+from .exceptions import *
 from capstone import *
 from capstone.x86 import *
 
@@ -31,40 +32,6 @@ IRETQ_OFFSET = 0x100
 IRETD_OFFSET = IRETQ_OFFSET + 1
 GDT_BASE = TSS_BASE - 0x3000
 
-# interrupts range 0x00-0xFF
-class ExceptionType(IntEnum):
-    NoException = 0x100
-    Memory = 0x101
-    Interrupt = 0x102
-    ContextSwitch = 0x103
-
-class MemoryException(IntEnum):
-    ReadUnmapped = 19
-    WriteUnmapped = 20
-    ExecuteUnmapped = 21
-    WriteProtection = 22
-    ReadProtection = 23
-    ExecuteProtection = 24
-
-class ExceptionInfo:
-    def __init__(self):
-        self.type = ExceptionType.NoException
-        self.memory_access = 0
-        self.memory_address = 0
-        self.memory_size = 0
-        self.memory_value = 0
-        self.interrupt_number = 0
-        self.code_hook_h: Optional[int] = None  # TODO: should be unicorn.uc_hook_h, but type error
-        self.context: Optional[unicorn.UcContext] = None
-        self.tb_start = 0
-        self.tb_size = 0
-        self.tb_icount = 0
-        self.step_count = 0
-        self.final = False
-        self.handling = False
-
-    def __str__(self):
-        return f"{self.type:x}, ({hex(self.tb_start)}, {hex(self.tb_size)}, {self.tb_icount})"
 
 class UnicornPageManager(PageManager):
     def __init__(self, uc: Uc) -> None:
@@ -255,13 +222,6 @@ class SimpleTimer:
         diff = self.time - prev
         print(f"{name}: {diff*1000:.0f}ms")
 
-class Breakpoint:
-    def __init__(self, address, callback, info):
-        self.address = address
-        self.original = 0
-        self.callback = callback
-        self.info = info
-
 class Dumpulator(Architecture):
     def __init__(self, minidump_file, *, trace=False, quiet=False, thread_id=None, debug_logs=False):
         self._quiet = quiet
@@ -312,8 +272,8 @@ class Dumpulator(Architecture):
         self.exports = self._all_exports()
         self.handles = HandleManager()
         self.exception = ExceptionInfo()
-        self._exception_hooks = {}
-        self._breakpoint_hooks = {}
+        self._hooks: Dict[int, Callable] = {}
+        self._breakpoint_hooks: Dict[int, Breakpoint] = {}
         self.last_exception: Optional[ExceptionInfo] = None
         if not self._quiet:
             print("Memory map:")
@@ -721,7 +681,7 @@ class Dumpulator(Architecture):
         self.memory.commit(self.memory.align_page(ptr), self.memory.align_page(size))
         return ptr
 
-    def add_breakpoint(self, address, callback, info=None):
+    def add_breakpoint(self, address: int, callback: Callable, info: any = None):
         assert address not in self._breakpoint_hooks, f'Breakpoint at 0x{address:x} already installed'
         assert callback is not None, f'No callback supplied to breakpoint 0x{address:x}'
         # setup breakpoint object, save original byte and write INT3
@@ -730,37 +690,37 @@ class Dumpulator(Architecture):
         self.write(address, b'\xCC')
         self._breakpoint_hooks[address] = bp
 
-    def _restore_breakpoint(self, address):
+    def _remove_breakpoint(self, address: int) -> int:
         assert address in self._breakpoint_hooks, f'No user breakpoint at 0x{address:x}'
         bp = self._breakpoint_hooks[address]
         self.write(bp.address, bp.original)
         self.info(f"restoring breakpoint: {address:x}")
         return address
 
-    def add_exception_hook(self, exception_type, func):
-        assert exception_type not in self._exception_hooks, f'Duplicate hook type {exception_type} installed'
-        self._exception_hooks[exception_type] = func
+    def _restore_breakpoint(self, address: int):
+        # TODO: restore breakpoint after it has been handled to enable us to hit the breakpoint again
+        pass
 
-    def handle_hooks(self):
+    def add_exception_hook(self, exception_type: Exceptions, func: Callable):
+        assert exception_type not in self._hooks, f'Duplicate hook type {exception_type} installed'
+        self.info(f'Install hook of type: {exception_type}')
+        self._hooks[exception_type] = func
+
+    def handle_hooks(self) -> Optional[int]:
         ret_val = None
-        # check if we have a user installed exception hook
-        if self.exception.type in self._exception_hooks:
-            callback = self._exception_hooks[self.exception.type]
-            ret_val = callback(self, self.exception)
 
         # first check if we have a user installed breakpoint
-        elif self.exception.type is ExceptionType.Interrupt and self.exception.interrupt_number == 3:
+        if self.exception.code is Exceptions.Interrupt_3:
             # cip has already incremented due to handling the breakpoint
             bp_addr = self.regs.cip - 1
             if bp_addr in self._breakpoint_hooks:
                 bp = self._breakpoint_hooks[bp_addr]
                 ret_val = bp.callback(self, bp)
                 if ret_val is None:
-                    ret_val = self._restore_breakpoint(bp_addr)
-
-        # lastly check if we have a user install interrupt hook
-        elif self.exception.interrupt_number in self._exception_hooks:
-            callback = self._exception_hooks[self.exception.interrupt_number]
+                    ret_val = self._remove_breakpoint(bp_addr)
+        # then ew check if we have a user installed exception hook
+        elif self.exception.code in self._hooks:
+            callback = self._hooks[self.exception.code]
             ret_val = callback(self, self.exception)
 
         if ret_val is not None:
@@ -845,15 +805,7 @@ rsp in KiUserExceptionDispatcher:
             record.ExceptionFlags = 0
             record.ExceptionAddress = self.regs.cip
             record.NumberParameters = 2
-            types = {
-                UC_MEM_READ_UNMAPPED: EXCEPTION_READ_FAULT,
-                UC_MEM_WRITE_UNMAPPED: EXCEPTION_WRITE_FAULT,
-                UC_MEM_FETCH_UNMAPPED: EXCEPTION_READ_FAULT,
-                UC_MEM_READ_PROT: EXCEPTION_READ_FAULT,
-                UC_MEM_WRITE_PROT: EXCEPTION_WRITE_FAULT,
-                UC_MEM_FETCH_PROT: EXCEPTION_EXECUTE_FAULT,
-            }
-            record.ExceptionInformation[0] = types[self.exception.memory_access]
+            record.ExceptionInformation[0] = self.exception.code.to_memory_fault()
             record.ExceptionInformation[1] = self.exception.memory_address
         elif self.exception.type == ExceptionType.Interrupt and self.exception.interrupt_number == 3:
             if self._x64:
@@ -909,7 +861,7 @@ rsp in KiUserExceptionDispatcher:
         emu_count = count
         while True:
             try:
-                if self.exception.type != ExceptionType.NoException:
+                if self.exception.type != Exceptions.NoException:
                     if self.exception.final:
                         # Restore the context (unicorn might mess with it before stopping)
                         if self.exception.context is not None:
@@ -1119,24 +1071,24 @@ def _hook_mem(uc: Uc, access, address, size, value, dp: Dumpulator):
         dp.debug(f"committed lazy page {hex(address)}[{hex(size)}]")
         return True
 
-    fetch_accesses = [UC_MEM_FETCH, UC_MEM_FETCH_PROT, UC_MEM_FETCH_UNMAPPED]
-    if access == UC_MEM_FETCH_UNMAPPED and address >= FORCE_KILL_ADDR - 0x10 and address <= FORCE_KILL_ADDR + 0x10 and dp.kill_me is not None:
+    code = translate_exception(access)
+
+    if code == Exceptions.MemExecuteUnmapped and address >= FORCE_KILL_ADDR - 0x10 and address <= FORCE_KILL_ADDR + 0x10 and dp.kill_me is not None:
         dp.error(f"forced exit memory operation {access} of {address:x}[{size:x}] = {value:X}")
         return False
-    if dp.exception.final and access in fetch_accesses:
+    if dp.exception.final and code.memory_access() is MemoryFlags.Execute:
         dp.debug(f"fetch from {hex(address)}[{size}] already reported")
         return False
     # TODO: figure out why when you start executing at 0 this callback is triggered more than once
     try:
         # Extract exception information
         exception = ExceptionInfo()
-        exception.type = ExceptionType.Memory
-        exception.memory_access = access
+        exception.code = code
         exception.memory_address = address
         exception.memory_size = size
         exception.memory_value = value
         exception.context = uc.context_save()
-        if access not in fetch_accesses:
+        if code.memory_access() is not MemoryFlags.Execute:
             tb = uc.ctl_request_cache(dp.regs.cip)
             exception.tb_start = tb.pc
             exception.tb_size = tb.size
@@ -1145,26 +1097,14 @@ def _hook_mem(uc: Uc, access, address, size, value, dp: Dumpulator):
         # Print exception info
         final = dp.trace or dp.exception.code_hook_h is not None
         info = "final" if final else "initial"
-        if access == UC_MEM_READ_UNMAPPED:
+        if code == Exceptions.MemReadUnmapped:
             dp.error(f"{info} unmapped read from {address:x}[{size:x}], cip = {dp.regs.cip:x}, exception: {exception}")
-        elif access == UC_MEM_WRITE_UNMAPPED:
+        elif code == Exceptions.MemWriteUnmapped:
             dp.error(f"{info} unmapped write to {address:x}[{size:x}] = {value:x}, cip = {dp.regs.cip:x}")
-        elif access == UC_MEM_FETCH_UNMAPPED:
+        elif code == Exceptions.MemExecuteUnmapped:
             dp.error(f"{info} unmapped fetch of {address:x}[{size:x}], cip = {dp.regs.rip:x}, cs = {dp.regs.cs:x}")
         else:
-            names = {
-                UC_MEM_READ: "UC_MEM_READ", # Memory is read from
-                UC_MEM_WRITE: "UC_MEM_WRITE", # Memory is written to
-                UC_MEM_FETCH: "UC_MEM_FETCH", # Memory is fetched
-                UC_MEM_READ_UNMAPPED: "UC_MEM_READ_UNMAPPED", # Unmapped memory is read from
-                UC_MEM_WRITE_UNMAPPED: "UC_MEM_WRITE_UNMAPPED", # Unmapped memory is written to
-                UC_MEM_FETCH_UNMAPPED: "UC_MEM_FETCH_UNMAPPED", # Unmapped memory is fetched
-                UC_MEM_WRITE_PROT: "UC_MEM_WRITE_PROT", # Write to write protected, but mapped, memory
-                UC_MEM_READ_PROT: "UC_MEM_READ_PROT", # Read from read protected, but mapped, memory
-                UC_MEM_FETCH_PROT: "UC_MEM_FETCH_PROT", # Fetch from non-executable, but mapped, memory
-                UC_MEM_READ_AFTER: "UC_MEM_READ_AFTER", # Memory is read from (successful access)
-            }
-            dp.error(f"{info} unsupported access {names.get(access, str(access))} of {address:x}[{size:x}] = {value:X}, cip = {dp.regs.cip:x}")
+            dp.error(f"{info} unsupported access {code} of {address:x}[{size:x}] = {value:X}, cip = {dp.regs.cip:x}")
 
         if final:
             # Make sure this is the same exception we expect
@@ -1172,8 +1112,8 @@ def _hook_mem(uc: Uc, access, address, size, value, dp: Dumpulator):
                 # TODO: Unicorn seems to attempt to execute the entire block before stopping emulation because of
                 #  this it will throw fetch exceptions for each byte until it reaches the end of the block.
                 #  These asserts will end up blowing up Dumpulator into an exception loop.
-                if access not in fetch_accesses:
-                    assert access == dp.exception.memory_access
+                if code.memory_access() is not MemoryFlags.Execute:
+                    assert code == dp.exception.code
                     assert address == dp.exception.memory_address
                     assert size == dp.exception.memory_size
                     assert value == dp.exception.memory_value
@@ -1331,6 +1271,7 @@ def _hook_interrupt(uc: Uc, number, dp: Dumpulator):
         # Extract exception information
         exception = ExceptionInfo()
         exception.type = ExceptionType.Interrupt
+        exception.code = Exceptions(Exceptions.Interrupt | number)
         exception.interrupt_number = number
         exception.context = uc.context_save()
         # TODO: this might crash if cip is not valid memory
@@ -1457,6 +1398,7 @@ def _hook_invalid(uc: Uc, dp: Dumpulator):
             assert dp.exception.type == ExceptionType.NoException
             exception = ExceptionInfo()
             exception.type = ExceptionType.ContextSwitch
+            exception.code = Exceptions.ContextSwitch
             exception.final = True
             dp.exception = exception
             return False  # NOTE: returning True would stop emulation

--- a/src/dumpulator/exceptions.py
+++ b/src/dumpulator/exceptions.py
@@ -1,0 +1,419 @@
+from dumpulator.native import *
+from enum import IntEnum
+from unicorn import *
+from unicorn.unicorn_const import *
+from typing import Callable
+
+
+class Breakpoint:
+    def __init__(self, address: int, callback: Callable, info: any):
+        self.address = address
+        self.original: Optional[bytes] = None
+        self.callback = callback
+        self.info = info
+
+
+class ExceptionInfo:
+    def __init__(self):
+        self.type: ExceptionType = ExceptionType.NoException
+        self.code: Exceptions = Exceptions.NoException
+        self.memory_address = 0
+        self.memory_size = 0
+        self.memory_value = 0
+        self.interrupt_number = 0
+        self.code_hook_h: Optional[int] = None  # TODO: should be unicorn.uc_hook_h, but type error
+        self.context: Optional[unicorn.UcContext] = None
+        self.tb_start = 0
+        self.tb_size = 0
+        self.tb_icount = 0
+        self.step_count = 0
+        self.final = False
+        self.handling = False
+
+    def __str__(self):
+        return f"{self.code:x}, ({hex(self.tb_start)}, {hex(self.tb_size)}, {self.tb_icount})"
+
+
+class ExceptionType(IntEnum):
+    NoException = 0x0000
+    Memory = 0x1000
+    Interrupt = 0x2000
+    ContextSwitch = 0x4000
+    Error = 0x8000
+
+
+class MemoryFlags(IntEnum):
+    Read = 0x10
+    Write = 0x20
+    Execute = 0x40
+    Unmapped = 0x100
+    Unaligned = 0x200
+    Protection = 0x400
+    After = 0x800
+
+
+# TODO: could be Flag instead of IntEnum and combine with ExceptionType to have 1 Enum Flag
+class Exceptions(IntEnum):
+    # No Exception
+    NoException = ExceptionType.NoException
+    Memory = ExceptionType.Memory
+    Interrupt = ExceptionType.Interrupt
+    ContextSwitch = ExceptionType.ContextSwitch
+    Error = ExceptionType.Error
+
+    # Memory Exceptions
+    MemRead = ExceptionType.Memory | MemoryFlags.Read
+    MemWrite = ExceptionType.Memory | MemoryFlags.Write
+    MemExecute = ExceptionType.Memory | MemoryFlags.Execute
+    MemReadUnmapped = ExceptionType.Memory | MemoryFlags.Read | MemoryFlags.Unmapped
+    MemWriteUnmapped = ExceptionType.Memory | MemoryFlags.Write | MemoryFlags.Unmapped
+    MemExecuteUnmapped = ExceptionType.Memory | MemoryFlags.Execute | MemoryFlags.Unmapped
+    MemReadProt = ExceptionType.Memory | MemoryFlags.Read | MemoryFlags.Protection
+    MemWriteProt = ExceptionType.Memory | MemoryFlags.Write | MemoryFlags.Protection
+    MemExecuteProt = ExceptionType.Memory | MemoryFlags.Execute | MemoryFlags.Protection
+    MemReadAfter = ExceptionType.Memory | MemoryFlags.Execute | MemoryFlags.After
+
+    # Interrupts
+    Interrupt_1 = ExceptionType.Interrupt | 1
+    Interrupt_2 = ExceptionType.Interrupt | 2
+    Interrupt_3 = ExceptionType.Interrupt | 3
+    Interrupt_4 = ExceptionType.Interrupt | 4
+    Interrupt_5 = ExceptionType.Interrupt | 5
+    Interrupt_6 = ExceptionType.Interrupt | 6
+    Interrupt_7 = ExceptionType.Interrupt | 7
+    Interrupt_8 = ExceptionType.Interrupt | 8
+    Interrupt_9 = ExceptionType.Interrupt | 9
+    Interrupt_A = ExceptionType.Interrupt | 10
+    Interrupt_B = ExceptionType.Interrupt | 11
+    Interrupt_C = ExceptionType.Interrupt | 12
+    Interrupt_D = ExceptionType.Interrupt | 13
+    Interrupt_E = ExceptionType.Interrupt | 14
+    Interrupt_F = ExceptionType.Interrupt | 15
+    Interrupt_10 = ExceptionType.Interrupt | 16
+    Interrupt_11 = ExceptionType.Interrupt | 17
+    Interrupt_12 = ExceptionType.Interrupt | 18
+    Interrupt_13 = ExceptionType.Interrupt | 19
+    Interrupt_14 = ExceptionType.Interrupt | 20
+    Interrupt_15 = ExceptionType.Interrupt | 21
+    Interrupt_16 = ExceptionType.Interrupt | 22
+    Interrupt_17 = ExceptionType.Interrupt | 23
+    Interrupt_18 = ExceptionType.Interrupt | 24
+    Interrupt_19 = ExceptionType.Interrupt | 25
+    Interrupt_1A = ExceptionType.Interrupt | 26
+    Interrupt_1B = ExceptionType.Interrupt | 27
+    Interrupt_1C = ExceptionType.Interrupt | 28
+    Interrupt_1D = ExceptionType.Interrupt | 29
+    Interrupt_1E = ExceptionType.Interrupt | 30
+    Interrupt_1F = ExceptionType.Interrupt | 31
+    Interrupt_20 = ExceptionType.Interrupt | 32
+    Interrupt_21 = ExceptionType.Interrupt | 33
+    Interrupt_22 = ExceptionType.Interrupt | 34
+    Interrupt_23 = ExceptionType.Interrupt | 35
+    Interrupt_24 = ExceptionType.Interrupt | 36
+    Interrupt_25 = ExceptionType.Interrupt | 37
+    Interrupt_26 = ExceptionType.Interrupt | 38
+    Interrupt_27 = ExceptionType.Interrupt | 39
+    Interrupt_28 = ExceptionType.Interrupt | 40
+    Interrupt_29 = ExceptionType.Interrupt | 41
+    Interrupt_2A = ExceptionType.Interrupt | 42
+    Interrupt_2B = ExceptionType.Interrupt | 43
+    Interrupt_2C = ExceptionType.Interrupt | 44
+    Interrupt_2D = ExceptionType.Interrupt | 45
+    Interrupt_2E = ExceptionType.Interrupt | 46
+    Interrupt_2F = ExceptionType.Interrupt | 47
+    Interrupt_30 = ExceptionType.Interrupt | 48
+    Interrupt_31 = ExceptionType.Interrupt | 49
+    Interrupt_32 = ExceptionType.Interrupt | 50
+    Interrupt_33 = ExceptionType.Interrupt | 51
+    Interrupt_34 = ExceptionType.Interrupt | 52
+    Interrupt_35 = ExceptionType.Interrupt | 53
+    Interrupt_36 = ExceptionType.Interrupt | 54
+    Interrupt_37 = ExceptionType.Interrupt | 55
+    Interrupt_38 = ExceptionType.Interrupt | 56
+    Interrupt_39 = ExceptionType.Interrupt | 57
+    Interrupt_3A = ExceptionType.Interrupt | 58
+    Interrupt_3B = ExceptionType.Interrupt | 59
+    Interrupt_3C = ExceptionType.Interrupt | 60
+    Interrupt_3D = ExceptionType.Interrupt | 61
+    Interrupt_3E = ExceptionType.Interrupt | 62
+    Interrupt_3F = ExceptionType.Interrupt | 63
+    Interrupt_40 = ExceptionType.Interrupt | 64
+    Interrupt_41 = ExceptionType.Interrupt | 65
+    Interrupt_42 = ExceptionType.Interrupt | 66
+    Interrupt_43 = ExceptionType.Interrupt | 67
+    Interrupt_44 = ExceptionType.Interrupt | 68
+    Interrupt_45 = ExceptionType.Interrupt | 69
+    Interrupt_46 = ExceptionType.Interrupt | 70
+    Interrupt_47 = ExceptionType.Interrupt | 71
+    Interrupt_48 = ExceptionType.Interrupt | 72
+    Interrupt_49 = ExceptionType.Interrupt | 73
+    Interrupt_4A = ExceptionType.Interrupt | 74
+    Interrupt_4B = ExceptionType.Interrupt | 75
+    Interrupt_4C = ExceptionType.Interrupt | 76
+    Interrupt_4D = ExceptionType.Interrupt | 77
+    Interrupt_4E = ExceptionType.Interrupt | 78
+    Interrupt_4F = ExceptionType.Interrupt | 79
+    Interrupt_50 = ExceptionType.Interrupt | 80
+    Interrupt_51 = ExceptionType.Interrupt | 81
+    Interrupt_52 = ExceptionType.Interrupt | 82
+    Interrupt_53 = ExceptionType.Interrupt | 83
+    Interrupt_54 = ExceptionType.Interrupt | 84
+    Interrupt_55 = ExceptionType.Interrupt | 85
+    Interrupt_56 = ExceptionType.Interrupt | 86
+    Interrupt_57 = ExceptionType.Interrupt | 87
+    Interrupt_58 = ExceptionType.Interrupt | 88
+    Interrupt_59 = ExceptionType.Interrupt | 89
+    Interrupt_5A = ExceptionType.Interrupt | 90
+    Interrupt_5B = ExceptionType.Interrupt | 91
+    Interrupt_5C = ExceptionType.Interrupt | 92
+    Interrupt_5D = ExceptionType.Interrupt | 93
+    Interrupt_5E = ExceptionType.Interrupt | 94
+    Interrupt_5F = ExceptionType.Interrupt | 95
+    Interrupt_60 = ExceptionType.Interrupt | 96
+    Interrupt_61 = ExceptionType.Interrupt | 97
+    Interrupt_62 = ExceptionType.Interrupt | 98
+    Interrupt_63 = ExceptionType.Interrupt | 99
+    Interrupt_64 = ExceptionType.Interrupt | 100
+    Interrupt_65 = ExceptionType.Interrupt | 101
+    Interrupt_66 = ExceptionType.Interrupt | 102
+    Interrupt_67 = ExceptionType.Interrupt | 103
+    Interrupt_68 = ExceptionType.Interrupt | 104
+    Interrupt_69 = ExceptionType.Interrupt | 105
+    Interrupt_6A = ExceptionType.Interrupt | 106
+    Interrupt_6B = ExceptionType.Interrupt | 107
+    Interrupt_6C = ExceptionType.Interrupt | 108
+    Interrupt_6D = ExceptionType.Interrupt | 109
+    Interrupt_6E = ExceptionType.Interrupt | 110
+    Interrupt_6F = ExceptionType.Interrupt | 111
+    Interrupt_70 = ExceptionType.Interrupt | 112
+    Interrupt_71 = ExceptionType.Interrupt | 113
+    Interrupt_72 = ExceptionType.Interrupt | 114
+    Interrupt_73 = ExceptionType.Interrupt | 115
+    Interrupt_74 = ExceptionType.Interrupt | 116
+    Interrupt_75 = ExceptionType.Interrupt | 117
+    Interrupt_76 = ExceptionType.Interrupt | 118
+    Interrupt_77 = ExceptionType.Interrupt | 119
+    Interrupt_78 = ExceptionType.Interrupt | 120
+    Interrupt_79 = ExceptionType.Interrupt | 121
+    Interrupt_7A = ExceptionType.Interrupt | 122
+    Interrupt_7B = ExceptionType.Interrupt | 123
+    Interrupt_7C = ExceptionType.Interrupt | 124
+    Interrupt_7D = ExceptionType.Interrupt | 125
+    Interrupt_7E = ExceptionType.Interrupt | 126
+    Interrupt_7F = ExceptionType.Interrupt | 127
+    Interrupt_80 = ExceptionType.Interrupt | 128
+    Interrupt_81 = ExceptionType.Interrupt | 129
+    Interrupt_82 = ExceptionType.Interrupt | 130
+    Interrupt_83 = ExceptionType.Interrupt | 131
+    Interrupt_84 = ExceptionType.Interrupt | 132
+    Interrupt_85 = ExceptionType.Interrupt | 133
+    Interrupt_86 = ExceptionType.Interrupt | 134
+    Interrupt_87 = ExceptionType.Interrupt | 135
+    Interrupt_88 = ExceptionType.Interrupt | 136
+    Interrupt_89 = ExceptionType.Interrupt | 137
+    Interrupt_8A = ExceptionType.Interrupt | 138
+    Interrupt_8B = ExceptionType.Interrupt | 139
+    Interrupt_8C = ExceptionType.Interrupt | 140
+    Interrupt_8D = ExceptionType.Interrupt | 141
+    Interrupt_8E = ExceptionType.Interrupt | 142
+    Interrupt_8F = ExceptionType.Interrupt | 143
+    Interrupt_90 = ExceptionType.Interrupt | 144
+    Interrupt_91 = ExceptionType.Interrupt | 145
+    Interrupt_92 = ExceptionType.Interrupt | 146
+    Interrupt_93 = ExceptionType.Interrupt | 147
+    Interrupt_94 = ExceptionType.Interrupt | 148
+    Interrupt_95 = ExceptionType.Interrupt | 149
+    Interrupt_96 = ExceptionType.Interrupt | 150
+    Interrupt_97 = ExceptionType.Interrupt | 151
+    Interrupt_98 = ExceptionType.Interrupt | 152
+    Interrupt_99 = ExceptionType.Interrupt | 153
+    Interrupt_9A = ExceptionType.Interrupt | 154
+    Interrupt_9B = ExceptionType.Interrupt | 155
+    Interrupt_9C = ExceptionType.Interrupt | 156
+    Interrupt_9D = ExceptionType.Interrupt | 157
+    Interrupt_9E = ExceptionType.Interrupt | 158
+    Interrupt_9F = ExceptionType.Interrupt | 159
+    Interrupt_A0 = ExceptionType.Interrupt | 160
+    Interrupt_A1 = ExceptionType.Interrupt | 161
+    Interrupt_A2 = ExceptionType.Interrupt | 162
+    Interrupt_A3 = ExceptionType.Interrupt | 163
+    Interrupt_A4 = ExceptionType.Interrupt | 164
+    Interrupt_A5 = ExceptionType.Interrupt | 165
+    Interrupt_A6 = ExceptionType.Interrupt | 166
+    Interrupt_A7 = ExceptionType.Interrupt | 167
+    Interrupt_A8 = ExceptionType.Interrupt | 168
+    Interrupt_A9 = ExceptionType.Interrupt | 169
+    Interrupt_AA = ExceptionType.Interrupt | 170
+    Interrupt_AB = ExceptionType.Interrupt | 171
+    Interrupt_AC = ExceptionType.Interrupt | 172
+    Interrupt_AD = ExceptionType.Interrupt | 173
+    Interrupt_AE = ExceptionType.Interrupt | 174
+    Interrupt_AF = ExceptionType.Interrupt | 175
+    Interrupt_B0 = ExceptionType.Interrupt | 176
+    Interrupt_B1 = ExceptionType.Interrupt | 177
+    Interrupt_B2 = ExceptionType.Interrupt | 178
+    Interrupt_B3 = ExceptionType.Interrupt | 179
+    Interrupt_B4 = ExceptionType.Interrupt | 180
+    Interrupt_B5 = ExceptionType.Interrupt | 181
+    Interrupt_B6 = ExceptionType.Interrupt | 182
+    Interrupt_B7 = ExceptionType.Interrupt | 183
+    Interrupt_B8 = ExceptionType.Interrupt | 184
+    Interrupt_B9 = ExceptionType.Interrupt | 185
+    Interrupt_BA = ExceptionType.Interrupt | 186
+    Interrupt_BB = ExceptionType.Interrupt | 187
+    Interrupt_BC = ExceptionType.Interrupt | 188
+    Interrupt_BD = ExceptionType.Interrupt | 189
+    Interrupt_BE = ExceptionType.Interrupt | 190
+    Interrupt_BF = ExceptionType.Interrupt | 191
+    Interrupt_C0 = ExceptionType.Interrupt | 192
+    Interrupt_C1 = ExceptionType.Interrupt | 193
+    Interrupt_C2 = ExceptionType.Interrupt | 194
+    Interrupt_C3 = ExceptionType.Interrupt | 195
+    Interrupt_C4 = ExceptionType.Interrupt | 196
+    Interrupt_C5 = ExceptionType.Interrupt | 197
+    Interrupt_C6 = ExceptionType.Interrupt | 198
+    Interrupt_C7 = ExceptionType.Interrupt | 199
+    Interrupt_C8 = ExceptionType.Interrupt | 200
+    Interrupt_C9 = ExceptionType.Interrupt | 201
+    Interrupt_CA = ExceptionType.Interrupt | 202
+    Interrupt_CB = ExceptionType.Interrupt | 203
+    Interrupt_CC = ExceptionType.Interrupt | 204
+    Interrupt_CD = ExceptionType.Interrupt | 205
+    Interrupt_CE = ExceptionType.Interrupt | 206
+    Interrupt_CF = ExceptionType.Interrupt | 207
+    Interrupt_D0 = ExceptionType.Interrupt | 208
+    Interrupt_D1 = ExceptionType.Interrupt | 209
+    Interrupt_D2 = ExceptionType.Interrupt | 210
+    Interrupt_D3 = ExceptionType.Interrupt | 211
+    Interrupt_D4 = ExceptionType.Interrupt | 212
+    Interrupt_D5 = ExceptionType.Interrupt | 213
+    Interrupt_D6 = ExceptionType.Interrupt | 214
+    Interrupt_D7 = ExceptionType.Interrupt | 215
+    Interrupt_D8 = ExceptionType.Interrupt | 216
+    Interrupt_D9 = ExceptionType.Interrupt | 217
+    Interrupt_DA = ExceptionType.Interrupt | 218
+    Interrupt_DB = ExceptionType.Interrupt | 219
+    Interrupt_DC = ExceptionType.Interrupt | 220
+    Interrupt_DD = ExceptionType.Interrupt | 221
+    Interrupt_DE = ExceptionType.Interrupt | 222
+    Interrupt_DF = ExceptionType.Interrupt | 223
+    Interrupt_E0 = ExceptionType.Interrupt | 224
+    Interrupt_E1 = ExceptionType.Interrupt | 225
+    Interrupt_E2 = ExceptionType.Interrupt | 226
+    Interrupt_E3 = ExceptionType.Interrupt | 227
+    Interrupt_E4 = ExceptionType.Interrupt | 228
+    Interrupt_E5 = ExceptionType.Interrupt | 229
+    Interrupt_E6 = ExceptionType.Interrupt | 230
+    Interrupt_E7 = ExceptionType.Interrupt | 231
+    Interrupt_E8 = ExceptionType.Interrupt | 232
+    Interrupt_E9 = ExceptionType.Interrupt | 233
+    Interrupt_EA = ExceptionType.Interrupt | 234
+    Interrupt_EB = ExceptionType.Interrupt | 235
+    Interrupt_EC = ExceptionType.Interrupt | 236
+    Interrupt_ED = ExceptionType.Interrupt | 237
+    Interrupt_EE = ExceptionType.Interrupt | 238
+    Interrupt_EF = ExceptionType.Interrupt | 239
+    Interrupt_F0 = ExceptionType.Interrupt | 240
+    Interrupt_F1 = ExceptionType.Interrupt | 241
+    Interrupt_F2 = ExceptionType.Interrupt | 242
+    Interrupt_F3 = ExceptionType.Interrupt | 243
+    Interrupt_F4 = ExceptionType.Interrupt | 244
+    Interrupt_F5 = ExceptionType.Interrupt | 245
+    Interrupt_F6 = ExceptionType.Interrupt | 246
+    Interrupt_F7 = ExceptionType.Interrupt | 247
+    Interrupt_F8 = ExceptionType.Interrupt | 248
+    Interrupt_F9 = ExceptionType.Interrupt | 249
+    Interrupt_FA = ExceptionType.Interrupt | 250
+    Interrupt_FB = ExceptionType.Interrupt | 251
+    Interrupt_FC = ExceptionType.Interrupt | 252
+    Interrupt_FD = ExceptionType.Interrupt | 253
+    Interrupt_FE = ExceptionType.Interrupt | 254
+    Interrupt_FF = ExceptionType.Interrupt | 255
+
+    # UC Errors
+    ErrNoMem = ExceptionType.Error | 1
+    ErrArch = ExceptionType.Error | 2
+    ErrHandle = ExceptionType.Error | 3
+    ErrMode = ExceptionType.Error | 4
+    ErrVersion = ExceptionType.Error | 5
+    ErrHook = ExceptionType.Error | 6
+    ErrInsnInvalid = ExceptionType.Error | 7
+    ErrMap = ExceptionType.Error | 8
+    ErrArg = ExceptionType.Error | 9
+    ErrHookExists = ExceptionType.Error | 10
+    ErrResource = ExceptionType.Error | 11
+    ErrException = ExceptionType.Error | 12
+
+    # UC Memory Errors
+    ErrReadUnmapped = ExceptionType.Error | MemoryFlags.Read | MemoryFlags.Unmapped
+    ErrWriteUnmapped = ExceptionType.Error | MemoryFlags.Write | MemoryFlags.Unmapped
+    ErrExecuteUnmapped = ExceptionType.Error | MemoryFlags.Execute | MemoryFlags.Unmapped
+    ErrReadProt = ExceptionType.Error | MemoryFlags.Read | MemoryFlags.Protection
+    ErrWriteProt = ExceptionType.Error | MemoryFlags.Write | MemoryFlags.Protection
+    ErrExecuteProt = ExceptionType.Error | MemoryFlags.Execute | MemoryFlags.Protection
+    ErrReadUnaligned = ExceptionType.Error | MemoryFlags.Read | MemoryFlags.Unaligned
+    ErrWriteUnaligned = ExceptionType.Error | MemoryFlags.Write | MemoryFlags.Unaligned
+    ErrExecuteUnaligned = ExceptionType.Error | MemoryFlags.Execute | MemoryFlags.Unaligned
+
+    def type(self) -> [ExceptionType, int]:
+        return ExceptionType(self & 0xF000)
+
+    def memory_access(self) -> MemoryFlags:
+        assert self.type() == ExceptionType.Memory
+        return MemoryFlags(self & 0xF0)
+
+    def to_memory_fault(self) -> int:
+        assert self.type() == ExceptionType.Memory, f'Exception is not type of Memory, code: {self}.'
+        types = {
+            MemoryFlags.Read: EXCEPTION_READ_FAULT,
+            MemoryFlags.Write: EXCEPTION_WRITE_FAULT,
+            MemoryFlags.Execute: EXCEPTION_EXECUTE_FAULT
+        }
+        return types[MemoryFlags(self.memory_access())]
+
+    def __repr__(self):
+        cls_name = self.__class__.__name__
+        return f'{cls_name}.{self.name}'
+
+    def __str__(self):
+        cls_name = self.__class__.__name__
+        return f'{cls_name}.{self.name}'
+
+
+def translate_exception(uc_code: int) -> Exceptions:
+    translation = {
+        UC_ERR_OK: Exceptions.NoException,
+        UC_ERR_NOMEM: Exceptions.ErrNoMem,
+        UC_ERR_ARCH: Exceptions.ErrArch,
+        UC_ERR_HANDLE: Exceptions.ErrHandle,
+        UC_ERR_MODE: Exceptions.ErrMode,
+        UC_ERR_VERSION: Exceptions.ErrVersion,
+        UC_ERR_READ_UNMAPPED: Exceptions.ErrReadUnmapped,
+        UC_ERR_WRITE_UNMAPPED: Exceptions.ErrWriteUnmapped,
+        UC_ERR_FETCH_UNMAPPED: Exceptions.ErrExecuteUnmapped,
+        UC_ERR_HOOK: Exceptions.ErrHook,
+        UC_ERR_INSN_INVALID: Exceptions.ErrInsnInvalid,
+        UC_ERR_MAP: Exceptions.ErrMap,
+        UC_ERR_WRITE_PROT: Exceptions.ErrWriteProt,
+        UC_ERR_READ_PROT: Exceptions.ErrReadProt,
+        UC_ERR_FETCH_PROT: Exceptions.ErrExecuteProt,
+        UC_ERR_ARG: Exceptions.ErrArg,
+        UC_ERR_READ_UNALIGNED: Exceptions.ErrReadUnaligned,
+        UC_ERR_WRITE_UNALIGNED: Exceptions.ErrWriteUnaligned,
+        UC_ERR_FETCH_UNALIGNED: Exceptions.ErrExecuteUnaligned,
+        UC_ERR_HOOK_EXIST: Exceptions.ErrHookExists,
+        UC_ERR_RESOURCE: Exceptions.ErrResource,
+        UC_ERR_EXCEPTION: Exceptions.ErrException,
+        UC_MEM_READ: Exceptions.MemRead,
+        UC_MEM_WRITE: Exceptions.MemWrite,
+        UC_MEM_FETCH: Exceptions.MemExecute,
+        UC_MEM_READ_UNMAPPED: Exceptions.MemReadUnmapped,
+        UC_MEM_WRITE_UNMAPPED: Exceptions.MemWriteUnmapped,
+        UC_MEM_FETCH_UNMAPPED: Exceptions.MemExecuteUnmapped,
+        UC_MEM_WRITE_PROT: Exceptions.MemWriteProt,
+        UC_MEM_READ_PROT: Exceptions.MemReadProt,
+        UC_MEM_FETCH_PROT: Exceptions.MemExecuteProt,
+        UC_MEM_READ_AFTER: Exceptions.MemReadAfter
+    }
+    assert uc_code in translation, f'Unknown UC code: {uc_code}.'
+    return translation[uc_code]

--- a/src/dumpulator/ntsyscalls.py
+++ b/src/dumpulator/ntsyscalls.py
@@ -1756,7 +1756,8 @@ def ZwFreeVirtualMemory(dp: Dumpulator,
     size = RegionSize.read_ptr()
     if FreeType == MEM_RELEASE:
         print(f"release {hex(base)}[{hex(size)}]")
-        assert size == 0
+        if size == 0:
+            return STATUS_INVALID_PARAMETER
         region = dp.memory.find_region(base)
         if region is None:
             return STATUS_MEMORY_NOT_ALLOCATED
@@ -2489,7 +2490,7 @@ def ZwOpenThreadToken(dp: Dumpulator,
                       OpenAsSelf: BOOLEAN,
                       TokenHandle: P(HANDLE)
                       ):
-    raise NotImplementedError()
+    return STATUS_SUCCESS
 
 @syscall
 def ZwOpenThreadTokenEx(dp: Dumpulator,

--- a/tests/ramen_noodle.py
+++ b/tests/ramen_noodle.py
@@ -1,0 +1,93 @@
+from dumpulator import *
+from dumpulator.dumpulator import *
+from dumpulator.handles import *
+from dumpulator.memory import *
+
+@syscall
+def ZwAllocateVirtualMemory(dp: Dumpulator,
+                            ProcessHandle: HANDLE,
+                            BaseAddress: P(PVOID),
+                            ZeroBits: ULONG_PTR,
+                            RegionSize: P(SIZE_T),
+                            AllocationType: ULONG,
+                            Protect: ULONG
+                            ):
+    assert ZeroBits == 0
+    assert ProcessHandle == dp.NtCurrentProcess()
+    base = dp.read_ptr(BaseAddress.ptr)
+    assert base & 0xFFF == 0
+    size = round_to_pages(dp.read_ptr(RegionSize.ptr))
+    assert size != 0
+    protect = MemoryProtect(Protect)
+    if AllocationType == MEM_COMMIT:
+        if base == 0:
+            base = dp.memory.find_free(size)
+            if protect == MemoryProtect.PAGE_EXECUTE_READWRITE:
+                dp.memory.reserve(base, size, MemoryProtect.PAGE_READWRITE, info='rwx')
+                print("found rwx commit")
+            else:
+                dp.memory.reserve(base, size, protect)
+            BaseAddress.write_ptr(base)
+            RegionSize.write_ptr(size)
+        print(f"commit({hex(base)}[{hex(size)}], {protect})")
+        if protect == MemoryProtect.PAGE_EXECUTE_READWRITE:
+            dp.memory.commit(base, size, MemoryProtect.PAGE_READWRITE)
+            print("found rwx commit")
+        else:
+            dp.memory.commit(base, size, protect)
+    elif AllocationType == MEM_RESERVE:
+        if base == 0:
+            base = dp.memory.find_free(size)
+            BaseAddress.write_ptr(base)
+            RegionSize.write_ptr(size)
+        print(f"reserve({hex(base)}[{hex(size)}], {protect})")
+        if protect == MemoryProtect.PAGE_EXECUTE_READWRITE:
+            dp.memory.reserve(base, size, MemoryProtect.PAGE_READWRITE, info='rwx')
+            print("found rwx commit")
+        else:
+            dp.memory.reserve(base, size, protect)
+    elif AllocationType == MEM_COMMIT | MEM_RESERVE:
+        if base == 0:
+            base = dp.memory.find_free(size)
+            BaseAddress.write_ptr(base)
+            RegionSize.write_ptr(size)
+        print(f"reserve+commit({hex(base)}[{hex(size)}], {protect})")
+        if protect == MemoryProtect.PAGE_EXECUTE_READWRITE:
+            dp.memory.reserve(base, size, MemoryProtect.PAGE_READWRITE, info='rwx')
+            print("found rwx commit")
+        else:
+            dp.memory.reserve(base, size, protect)
+        dp.memory.commit(base, size)
+    else:
+        assert False
+    return STATUS_SUCCESS
+
+STOP_CODE = 0xDEADBEEF
+
+def exception_hook(dp: Dumpulator, exception: ExceptionInfo):
+    if exception.memory_access == MemoryException.ExecuteProtection:
+        print(f'catching ExecuteProtection 0x{dp.regs.cip:x}')
+        mem_region = dp.memory.find_region(dp.regs.cip)
+        if mem_region.info == 'rwx':
+            print(f'potential stage3 buffer {mem_region}')
+            data = dp.memory.read(mem_region.start, mem_region.size)
+
+            print(f'first bytes of region: {data[:0x20]}')
+            mem_region.protect = MemoryProtect.PAGE_EXECUTE_READWRITE
+
+            save_file = rf'E:/tmp/ramen_{mem_region.start:x}.bin'
+            with open(save_file, 'wb') as f:
+                f.write(data)
+                print(f'Saved dump to "{save_file}"')
+                return STOP_CODE
+
+
+def test_bp(dp: Dumpulator, data: Breakpoint):
+    print(f'we hit a bp! info: {data.info} address: {data.address:x} original: {data.original}')
+
+dp = Dumpulator("E:/tmp/stage2.dmp", quiet=True)
+
+dp.add_breakpoint(0x6CE352, test_bp, 'entrypoint bp')
+dp.add_exception_hook(ExceptionType.Memory, exception_hook)
+
+dp.start(dp.regs.eip, end=STOP_CODE)

--- a/tests/ramen_noodle.py
+++ b/tests/ramen_noodle.py
@@ -72,7 +72,7 @@ def exception_hook(dp: Dumpulator, exception: ExceptionInfo):
             print(f'potential stage3 buffer {mem_region}')
             data = dp.memory.read(mem_region.start, mem_region.size)
 
-            print(f'first bytes of region: {data[:0x20]}')
+            print(f'first bytes of region: {data[:0x10]}')
             mem_region.protect = MemoryProtect.PAGE_EXECUTE_READWRITE
 
             save_file = rf'E:/tmp/ramen_{mem_region.start:x}.bin'
@@ -85,9 +85,9 @@ def exception_hook(dp: Dumpulator, exception: ExceptionInfo):
 def test_bp(dp: Dumpulator, data: Breakpoint):
     print(f'we hit a bp! info: {data.info} address: {data.address:x} original: {data.original}')
 
-dp = Dumpulator("E:/tmp/stage2.dmp", quiet=True)
+dp = Dumpulator("E:/tmp/stage2.dmp", quiet=False)
 
-dp.add_breakpoint(0x6CE352, test_bp, 'entrypoint bp')
+# dp.add_breakpoint(0x6CE352, test_bp, 'entrypoint bp')
 dp.add_exception_hook(ExceptionType.Memory, exception_hook)
 
 dp.start(dp.regs.eip, end=STOP_CODE)


### PR DESCRIPTION
Putting it as a PR to allow and easy code change view.

Output of ramen_noodle.py:

<details>
<summary>`quiet=True`</summary>

```
interrupt 3 (#BP, Breakpoint), cip = 6ce353, cs = 23
we hit a bp! info: entrypoint bp address: 6ce352 original: bytearray(b'\xe8')
commit(0x6ea000[0x1d000], PAGE_READWRITE)
found rwx commit
commit(0x1180000[0x1d000], PAGE_EXECUTE_READWRITE)
found rwx commit
initial unsupported access UC_MEM_FETCH_PROT of 118607f[1] = 0, cip = 118607f
final unsupported access UC_MEM_FETCH_PROT of 1186080[1] = 0, cip = 118607f
catching ExecuteProtection 0x118607f
potential stage3 buffer 0x1180000[0x1d000] (rwx)
first bytes of region: bytearray(b'RSL\x01\x05\x00d\x00\x7f`\x00\x00\x80\xcd\x01\x00\x18\x01\x00\x00\x00\xad\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00')
Saved dump to "E:/tmp/ramen_1180000.bin"
```

</details>

<details>
<summary>`quiet=False`</summary>

```
emu_start(6ce320, deadbeef, 0)
interrupt 3 (#BP, Breakpoint), cip = 6ce353, cs = 23
handling exception...
we hit a bp! info: entrypoint bp address: 6ce352 original: bytearray(b'\xe8')
restoring breakpoint: 6ce352
emu_start(6ce352, deadbeef, 0)
syscall: ZwAllocateVirtualMemory(
    HANDLE ProcessHandle = 0xffffffff /* NtCurrentProcess() */,
    PVOID* BaseAddress = 0x19f96c,
    ULONG_PTR ZeroBits = 0x0,
    SIZE_T* RegionSize = 0x19f99c,
    ULONG AllocationType = 0x1000,
    ULONG Protect = 0x4
)
commit(0x6ea000[0x1d000], PAGE_READWRITE)
status = 0
syscall: ZwAllocateVirtualMemory(
    HANDLE ProcessHandle = 0xffffffff /* NtCurrentProcess() */,
    PVOID* BaseAddress = 0x19fec4,
    ULONG_PTR ZeroBits = 0x0,
    SIZE_T* RegionSize = 0x19fec0,
    ULONG AllocationType = 0x1000,
    ULONG Protect = 0x40
)
found rwx commit
commit(0x1180000[0x1d000], PAGE_EXECUTE_READWRITE)
found rwx commit
status = 0
syscall: ZwAccessCheck(
    SECURITY_DESCRIPTOR* SecurityDescriptor = 0xffffffff,
    HANDLE ClientToken = 0x19fec4,
    ACCESS_MASK DesiredAccess = 0x0,
    GENERIC_MAPPING* GenericMapping = 0x19fec0,
    PRIVILEGE_SET* PrivilegeSet = 0x1000,
    ULONG* PrivilegeSetLength = 0x40,
    ACCESS_MASK* GrantedAccess = 0x6e8368,
    NTSTATUS* AccessStatus = 0x1d000
)
status = 0
initial unsupported access UC_MEM_FETCH_PROT of 118607f[1] = 0, cip = 118607f
final unsupported access UC_MEM_FETCH_PROT of 1186080[1] = 0, cip = 118607f
fetch from 0x1186081[1] already reported
fetch from 0x1186082[1] already reported
fetch from 0x1186083[1] already reported
...
(continues for a long time, it's a bug)
...
fetch from 0x11862b9[1] already reported
fetch from 0x11862ba[1] already reported
handling exception...
catching ExecuteProtection 0x118607f
potential stage3 buffer 0x1180000[0x1d000] (rwx)
first bytes of region: bytearray(b'RSL\x01\x05\x00d\x00\x7f`\x00\x00\x80\xcd\x01\x00\x18\x01\x00\x00\x00\xad\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00')
Saved dump to "E:/tmp/ramen_1180000.bin"
emu_start(deadbeef, deadbeef, 0)
emulation finished, cip = deadbeef

Process finished with exit code 0

```

</details>
